### PR TITLE
correção do botão ADICIONAR da pagina cadastroProjetos.php

### DIFF
--- a/App/View/pages/adm/cadastroTurmas/CadastroProjetos.php
+++ b/App/View/pages/adm/cadastroTurmas/CadastroProjetos.php
@@ -75,9 +75,13 @@ $is_admin = isset($_SESSION['usuario']) && $_SESSION['usuario']['perfil'] === 'a
       ?>
 
       <div class="primaty-button">
-        <a href="imagens.php">
-          <?php buttonComponent('primary', 'ADICIONAR', false, VARIAVEIS['APP_URL'] . VARIAVEIS['DIR_ADM'] . 'cadastroTurmas/Projeto.php'); ?>
-        </a>
+          <?php 
+            $linkAdicionarProjeto = VARIAVEIS['APP_URL'] . VARIAVEIS['DIR_ADM'] . 'cadastroTurmas/Projeto.php';
+            if ($turmaId) {
+                $linkAdicionarProjeto .= '?id=' . $turmaId;
+            }
+            buttonComponent('primary', 'ADICIONAR', false, $linkAdicionarProjeto); 
+          ?>
       </div>
 
       <?php if (empty($projetos)): ?>


### PR DESCRIPTION
quando clicava nele ele voltava para a listagem das turmas O botão estava incorretamente envolvido por um link (<a>) que apontava para o arquivo imagens.php, e ao mesmo tempo, não passava o ID da turma para a página de criação do projeto. Agora, ao clicar em ADICIONAR, você será levado
para a página de cadastro do novo projeto, mantendo o contexto da turma selecionada.